### PR TITLE
feat: implement generate-doc.js prototype (#2)

### DIFF
--- a/.github/workflows/auto-update-readme.yml
+++ b/.github/workflows/auto-update-readme.yml
@@ -1,0 +1,31 @@
+name: Update README.md for summary pull requests on this week.
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update-readme:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Node 12.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+
+      - name: Install Node.js Dependencies
+        run: |
+          npm install
+
+      - name: Update README.md and LOG.md
+        run: |
+          node generate-docs.js
+
+      - name: Git auto commit action
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: 'docs: Update summary in README.md and LOG.md (auto)'

--- a/.github/workflows/auto-update-readme.yml
+++ b/.github/workflows/auto-update-readme.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Install Node.js Dependencies
         run: |
-          npm install
+          npm ci
 
       - name: Update README.md and LOG.md
         run: |

--- a/README.md
+++ b/README.md
@@ -2,6 +2,27 @@
 
 > 👨‍💻 일주일에 최소 5개의 알고리즘 문제를 푸는 스터디
 
+<!-- Summary Start -->
+## 이번 주(39주차) 요약
+
+### <img src="https://avatars2.githubusercontent.com/u/16265376?v=4" height="17px" width="17px"> agrajak
+| 문제이름 | 해결 여부 | 링크 | 
+| :-------: | :-------: | :------: |
+|  Programmers 42579  | ✅ | [바로가기](https://github.com/five-per-week/algorithms/pull/15) |
+|  Programmers 42577  | ✅ | [바로가기](https://github.com/five-per-week/algorithms/pull/14) |
+
+
+
+### <img src="https://avatars2.githubusercontent.com/u/48426991?v=4" height="17px" width="17px"> younho9
+| 문제이름 | 해결 여부 | 링크 | 
+| :-------: | :-------: | :------: |
+|  Programmers 42579  | ✅ | [바로가기](https://github.com/five-per-week/algorithms/pull/13) |
+|  Programmers 42578  | ✅ | [바로가기](https://github.com/five-per-week/algorithms/pull/10) |
+|  Programmers 42577  | ✅ | [바로가기](https://github.com/five-per-week/algorithms/pull/9) |
+|  Solved programmers-42576 | ✅ | [바로가기](https://github.com/five-per-week/algorithms/pull/6) |
+
+<!-- Summary End -->
+
 ## 스터디 규칙
 
 -   문제를 풀기 전 `branch`를 이동합니다.

--- a/generate-docs.js
+++ b/generate-docs.js
@@ -1,0 +1,97 @@
+const axios = require('axios');
+const dayjs = require('dayjs');
+const fs = require('fs');
+
+const LR = '\r\n';
+
+function initDayJS() {
+    var utc = require('dayjs/plugin/utc'); // dependent on utc plugin
+    var timezone = require('dayjs/plugin/timezone');
+    var weekOfYear = require('dayjs/plugin/weekOfYear');
+    require('dayjs/locale/ko');
+    dayjs().locale('ko').format();
+    dayjs.extend(utc);
+    dayjs.extend(timezone);
+    dayjs.tz.setDefault('Asia/Seoul');
+    dayjs.extend(weekOfYear);
+}
+
+function hasAlgorithmLabel(pr) {
+    return pr.labels.some((label) => {
+        if (label.name == 'algorithm') return true;
+        return false;
+    });
+}
+function getUsersFromPullRequests(prs) {
+    return Object.values(
+        prs.reduce((acc, pr) => {
+            const id = pr.user.login;
+            if (!(id in acc)) {
+                acc[id] = Object.assign(pr.user, { prs: [] });
+            }
+            acc[id].prs.push(pr);
+
+            return acc;
+        }, new Map()),
+    );
+}
+async function fetchPullRequests() {
+    const { data } = await axios.get(
+        'https://api.github.com/repos/five-per-week/algorithms/pulls?state=closed',
+    );
+    return data;
+}
+function generatePullRequestRow(pr) {
+    const isSolved = pr.title.indexOf('✅') != -1 ? '✅' : '❌';
+    const title = pr.title.match(/:(.*)[@\s]/)[1];
+    const url = pr.html_url;
+    return `| ${title} | ${isSolved} | [바로가기](${url}) |`;
+}
+
+function generateTable(prs) {
+    const tRow = '| :-------: | :-------: | :------: |' + LR;
+    return (
+        '| 문제이름 | 해결 여부 | 링크 | ' +
+        LR +
+        tRow +
+        prs.map(generatePullRequestRow).join(LR) +
+        LR
+    );
+}
+async function generateSummary() {
+    const weekOfYear = dayjs().week();
+
+    const pullRequestsThisWeek = (await fetchPullRequests())
+        .filter(hasAlgorithmLabel)
+        .filter((x) => dayjs(x.created_at).week() == weekOfYear);
+
+    const header = LR + `## 이번 주(${weekOfYear}주차) 요약` + LR;
+    return (
+        header +
+        getUsersFromPullRequests(pullRequestsThisWeek)
+            .map((user) => {
+                return (
+                    LR +
+                    `### <img src="${user.avatar_url}" height="17px" width="17px"> ${user.login}` +
+                    LR +
+                    generateTable(user.prs) +
+                    LR
+                );
+            })
+            .join(LR)
+    );
+}
+
+initDayJS();
+(async function () {
+    const readme = fs.readFileSync('./README.md', 'utf8');
+    const summary = await generateSummary();
+    const getCommentRegex = /(^[\s\S]*Start -->)([\S\s]*)(<!--[\s\S]*$)/;
+
+    fs.writeFileSync(
+        './README.md',
+        readme.replace(getCommentRegex, (match, start, comment, end) =>
+            [start, summary, end].join(''),
+        ),
+    );
+})();

--- a/package-lock.json
+++ b/package-lock.json
@@ -912,6 +912,14 @@
       "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==",
       "dev": true
     },
+    "axios": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
+      "integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
+    },
     "babel-jest": {
       "version": "26.3.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.3.0.tgz",
@@ -1360,6 +1368,11 @@
         "whatwg-url": "^8.0.0"
       }
     },
+    "dayjs": {
+      "version": "1.8.36",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.36.tgz",
+      "integrity": "sha512-3VmRXEtw7RZKAf+4Tv1Ym9AGeo8r8+CjDi26x+7SYQil1UqtqdaokhzoEJohqlzt0m5kacJSDhJQkG/LWhpRBw=="
+    },
     "debug": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
@@ -1806,6 +1819,11 @@
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
       }
+    },
+    "follow-redirects": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
+      "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA=="
     },
     "for-in": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
     "name": "algorithms",
     "version": "1.0.0",
     "description": "",
-    "dependencies": {},
+    "dependencies": {
+        "axios": "^0.20.0",
+        "dayjs": "^1.8.36"
+    },
     "devDependencies": {
         "create-ps-directory": "1.0.3",
         "jest": "26.4.2",


### PR DESCRIPTION
README.md에 
```md
<!-- Summary Start -->
<!-- Summary End -->
```
를 추가해주면, 풀 리퀘스트 정보를 불러와 이번 주에 풀린 문제를 유저별로 정리하고, Comment 안의 정보를 replace한다.

급하게 만든다고 일단 함수 네이밍도 다 엉망!!

결과물: 
[링크 바로가기](https://github.com/five-per-week/algorithms/tree/feat/generate-docs-auto)

스크린샷:
![image](https://user-images.githubusercontent.com/16265376/94017546-8728e400-fdea-11ea-8c41-00ed1cd16437.png)

이걸 CI/CI로 master에 merge 될 때 마다 실행시키면 괜찮을듯??
