### PR TITLE
fix: add --force option for git-auto-commit

### DIFF
--- a/.github/workflows/auto-update-readme.yml
+++ b/.github/workflows/auto-update-readme.yml
@@ -23,9 +23,10 @@ jobs:
 
       - name: Update README.md and LOG.md
         run: |
-          node generate-docs.js
+          npm run update-docs
 
       - name: Git auto commit action
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: 'docs: Update summary in README.md and LOG.md (auto)'
+          push_options: --force

--- a/.github/workflows/auto-update-readme.yml
+++ b/.github/workflows/auto-update-readme.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.PAT }}
 
       - name: Set up Node 12.x
         uses: actions/setup-node@v1

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     },
     "scripts": {
         "test": "jest --watchAll --verbose",
-        "create": "create-ps-directory"
+        "create": "create-ps-directory",
+        "update-docs": "node generate-docs.js"
     },
     "license": "ISC"
 }


### PR DESCRIPTION
### 테스트
Forked repository에서 테스트 함 [링크](https://github.com/agrajak/algorithms/commit/c68d9af605b038fe2961110742561ef78b0bd5e2)

### 내용
- Settings > Secrets 에 `PAT` secret 추가
- npm scripts에 `update-docs` 추가
- `git-auto-commit`에 `push_options: --force` 추가
- `checkout` action에 token 추가 (`${{ secrets.PAT }}`)


이거 한 이틀은 걸릴 줄 알았는데 덕분에 진짜 금방했다 ㅋㅋㅋ
심심할때마다 이거 기능 추가해야지..

- this closes #20 
